### PR TITLE
fix cins issuer num

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,7 +485,12 @@ impl CUSIP {
 
     /// Return just the _Issuer Number_ portion of the CUSIP.
     pub fn issuer_num(&self) -> &str {
-        unsafe { from_utf8_unchecked(&self.as_bytes()[0..6]) } // This is safe because we know it is ASCII
+        if self.is_cins() { // This is safe because we know it is ASCII
+            // CINS excludes country code
+            unsafe { from_utf8_unchecked(&self.as_bytes()[1..6]) } 
+        } else {
+            unsafe { from_utf8_unchecked(&self.as_bytes()[0..6]) }
+        }
     }
 
     /// Returns true if the _Issuer Number_ is reserved for private use.


### PR DESCRIPTION
Hello,
I noticed that when calling .issuer_num() on a CINS, it includes the Country Code as part of the issuer number, which is not what I would expect based on the example [here](https://www.cusip.com/identifiers.html#/CINS).
```rust
use cusip;
fn main() {
    let cins = "G0052B105";
    let parsed = cusip::parse(cins).expect("unable to parse");
    println!("{}", parsed.issuer_num());
}
```
produces G0052B, where I expect 0052B